### PR TITLE
Syntax fixes and tests.

### DIFF
--- a/src/main/java/org/orbisgis/overpass4j/set/Area.java
+++ b/src/main/java/org/orbisgis/overpass4j/set/Area.java
@@ -63,15 +63,6 @@ public class Area extends SubSet {
         }
     }
 
-    public Area(Operator operator, Bbox bbox, List<Filter> filterList){
-        this.objectType = ObjectType.AREA;
-        this.operator =operator;
-        this.bbox = bbox;
-        for(Filter filter : filterList){
-            this.filterList.add(filter.copy());
-        }
-    }
-
     public Area call(String ... filters){
         return new Area(filters);
     }

--- a/src/main/java/org/orbisgis/overpass4j/set/DefaultSet.java
+++ b/src/main/java/org/orbisgis/overpass4j/set/DefaultSet.java
@@ -38,4 +38,16 @@ public class DefaultSet extends SubSet {
     public String toString(){
         return "."+alias+";";
     }
+
+    public DefaultSet call(){
+        return new DefaultSet();
+    }
+
+    public DefaultSet call(String alias){
+        return new DefaultSet(alias);
+    }
+
+    public DefaultSet call(SubSet set){
+        return new DefaultSet(set);
+    }
 }

--- a/src/main/java/org/orbisgis/overpass4j/set/ForEach.java
+++ b/src/main/java/org/orbisgis/overpass4j/set/ForEach.java
@@ -51,16 +51,16 @@ public class ForEach extends SubSet {
             str.append(".");
             str.append(inputSetAlias);
         }
-        str.append("{");
-        for(Query query : queries) {
-            query.format(null);
-            str.append(query.toString());
-        }
-        str.append("}");
         if(alias != null && !alias.isEmpty()){
             str.append("->.");
             str.append(alias);
         }
+        str.append("(");
+        for(Query query : queries) {
+            query.format(null);
+            str.append(query.toString());
+        }
+        str.append(")");
         str.append(";");
         return str.toString();
     }

--- a/src/main/java/org/orbisgis/overpass4j/set/Node.java
+++ b/src/main/java/org/orbisgis/overpass4j/set/Node.java
@@ -66,6 +66,10 @@ public class Node extends NRWSet {
         }
     }
 
+    public Node call(int identifier){
+        return new Node(identifier);
+    }
+
     public Node call(String ... filters){
         return new Node(filters);
     }

--- a/src/main/java/org/orbisgis/overpass4j/set/Set.java
+++ b/src/main/java/org/orbisgis/overpass4j/set/Set.java
@@ -47,6 +47,9 @@ public class Set {
     public Set minus(Set set){
         List<SubSet> subList = new ArrayList<>();
         for(SubSet subSet : subSetList){
+            subList.add(subSet.copy());
+        }
+        for(SubSet subSet : set.subSetList){
             SubSet sub = subSet.copy();
             if(sub.getOperator().equals(SubSet.Operator.UNION)){
                 sub.setOperator(SubSet.Operator.DIFFERENCE);
@@ -55,9 +58,6 @@ public class Set {
                 sub.setOperator(SubSet.Operator.UNION);
             }
             subList.add(sub);
-        }
-        for(SubSet subSet : set.getSubSetList().subList(1, set.getSubSetList().size())){
-            subList.add(subSet.copy());
         }
         return new Set(subList.toArray(new SubSet[]{}));
     }

--- a/src/main/java/org/orbisgis/overpass4j/set/SubSet.java
+++ b/src/main/java/org/orbisgis/overpass4j/set/SubSet.java
@@ -26,7 +26,7 @@ import java.util.List;
  * @author Sylvain PALOMINOS (UBS 2018)
  * @author Erwan Bocher (CNRS)
  */
-public abstract class SubSet {
+public abstract class SubSet extends Set{
 
     protected ObjectType objectType;
     protected Operator operator;
@@ -110,11 +110,8 @@ public abstract class SubSet {
         StringBuilder str = new StringBuilder();
         str.append(operatorToString());
         str.append(objectType.name().toLowerCase());
-        if(bbox != null && bbox.isArea()) {
-            str.append(bboxToString());
-        }
         str.append(filterToString());
-        if(bbox != null && !bbox.isArea()){
+        if(bbox != null){
             str.append(bboxToString());
         }
         str.append(aliasToString());

--- a/src/test/java/org/orbisgis/overpass4j/QueryTest.java
+++ b/src/test/java/org/orbisgis/overpass4j/QueryTest.java
@@ -1,16 +1,18 @@
 package org.orbisgis.overpass4j;
 
 import groovy.lang.GroovyShell;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.orbisgis.overpass4j.outformat.CsvOutFormat;
 import org.orbisgis.overpass4j.outformat.JsonOutFormat;
+import org.orbisgis.overpass4j.outformat.XmlOutFormat;
 import org.orbisgis.overpass4j.set.*;
 
 import java.io.File;
+import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class QueryTest {
 
@@ -19,41 +21,80 @@ public class QueryTest {
     @Before
     public void init(){
         shell = new GroovyShell(this.getClass().getClassLoader());
-        shell.setProperty("node", new Node());
-        shell.setProperty("way", new Way());
-        shell.setProperty("area", new Area());
-        shell.setProperty("rel", new Rel());
-        shell.setProperty("bbox", new Bbox(0, 0, 0, 0));
-        shell.setProperty("set", new Set());
-        shell.setProperty("query", new Query());
-        shell.setProperty("json", new JsonOutFormat());
-        shell.setProperty("csv", new CsvOutFormat());
-        shell.setProperty("skel", Out.skel);
+
+        shell.setProperty("area", OP4JObjects.area);
+        shell.setProperty("bbox", OP4JObjects.bbox);
+        shell.setProperty("csv", OP4JObjects.csv);
+        shell.setProperty("defaultSet", OP4JObjects.defaultSet);
+        shell.setProperty("foreach", OP4JObjects.foreach);
+        shell.setProperty("json", OP4JObjects.json);
+        shell.setProperty("map_to_area", OP4JObjects.map_to_area);
+        shell.setProperty("node", OP4JObjects.node);
+        shell.setProperty("query", OP4JObjects.query);
+        shell.setProperty("recurseDown", OP4JObjects.recurseDown);
+        shell.setProperty("recurseUp", OP4JObjects.recurseUp);
+        shell.setProperty("rel", OP4JObjects.rel);
+        shell.setProperty("set", OP4JObjects.set);
+        shell.setProperty("way", OP4JObjects.way);
+        shell.setProperty("xml", OP4JObjects.xml);
+
+        shell.setProperty("asc", Out.asc);
+        shell.setProperty("bb", Out.bb);
         shell.setProperty("body", Out.body);
-        shell.setProperty("recurseUp", new RecurseUp());
-        shell.setProperty("recurseDown", new RecurseDown());
-        shell.setProperty("map_to_area", new MapToArea());
-        shell.setProperty("foreach", new ForEach());
+        shell.setProperty("center", Out.center);
+        shell.setProperty("count", Out.count);
+        shell.setProperty("geom", Out.geom);
+        shell.setProperty("ids", Out.ids);
+        shell.setProperty("meta", Out.meta);
+        shell.setProperty("qt", Out.qt);
+        shell.setProperty("skel", Out.skel);
+        shell.setProperty("tags", Out.tags);
     }
 
     @Test
     public void javaQueryTest() {
         //Test subsets
+        //Test Node
         Node node = new Node(new Bbox(47, -3, 48, -2), "name=Vannes", "population");
         assertEquals("node[\"name\"=\"Vannes\"][\"population\"](47.0,-3.0,48.0,-2.0);", node.toString());
         Node nodeNoBBox = new Node("name=Vannes", "population");
         assertEquals("node[\"name\"=\"Vannes\"][\"population\"];", nodeNoBBox.toString());
+
+        //Test Way
         Way way = new Way(new Bbox(47.0, -3.0, 48.0, -2.0), "name=Vannes", "website");
         assertEquals("way[\"name\"=\"Vannes\"][\"website\"](47.0,-3.0,48.0,-2.0);", way.toString());
+
+        //Test Rel
         Rel rel = new Rel(new Bbox(47.0, -3.0, 48.0, -2.0), "name=Vannes", "capital");
         assertEquals("rel[\"name\"=\"Vannes\"][\"capital\"](47.0,-3.0,48.0,-2.0);", rel.toString());
+
+        //Test Area
         Area area = new Area(new Bbox(47.0, -3.0, 48.0, -2.0), "name=Vannes", "historic");
         assertEquals("area[\"name\"=\"Vannes\"][\"historic\"](47.0,-3.0,48.0,-2.0);", area.toString());
+
+        //Test set add and remove
+        Set set1 = new Set(new Node("name=Vannes", "population"), new Way("name=Vannes", "population"),
+                new Rel("name=Vannes", "population"));
+        Set set2 = new Set(new Node("name=Vannes", "historic"), new Way("name=Vannes", "historic"),
+                new Rel("name=Vannes", "historic"));
+        assertEquals("(node[\"name\"=\"Vannes\"][\"population\"];way[\"name\"=\"Vannes\"][\"population\"];" +
+                        "rel[\"name\"=\"Vannes\"][\"population\"];node[\"name\"=\"Vannes\"][\"historic\"];" +
+                        "way[\"name\"=\"Vannes\"][\"historic\"];rel[\"name\"=\"Vannes\"][\"historic\"];);",
+                set1.plus(set2).toString());
+        assertEquals("(node[\"name\"=\"Vannes\"][\"population\"];way[\"name\"=\"Vannes\"][\"population\"];" +
+                        "rel[\"name\"=\"Vannes\"][\"population\"];-node[\"name\"=\"Vannes\"][\"historic\"];" +
+                        "-way[\"name\"=\"Vannes\"][\"historic\"];-rel[\"name\"=\"Vannes\"][\"historic\"];);",
+                set1.minus(set2).toString());
+
+        //Test operator
+        Node nodeOp = new Node("name=Vannes", "name!=Vannes", "name!~Vannes", "name~Vannes", "!name");
+        assertEquals("node[\"name\"=\"Vannes\"][\"name\"!=\"Vannes\"][\"name\"!~\"Vannes\"][\"name\"~\"Vannes\"]" +
+                "[!\"name\"];", nodeOp.toString());
 
         //Test comparison filter
         Node compFilter = new Node(new Bbox(47, -3, 48, -2), "building:levels>=3", "building:levels<5");
         assertEquals("node(if:t[\"building:levels\"]>=3)(if:t[\"building:levels\"]<5)(47.0,-3.0,48.0,-2.0);", compFilter.toString());
-        compFilter = new Node(new Bbox(47, -3, 48, -2), "building:levels>3", "building:levels<=5");
+        compFilter = new Node(new Bbox(47, -3, 48, -2), "building:levels > 3", "building:levels<=5");
         assertEquals("node(if:t[\"building:levels\"]>3)(if:t[\"building:levels\"]<=5)(47.0,-3.0,48.0,-2.0);", compFilter.toString());
 
         //Test set
@@ -64,12 +105,14 @@ public class QueryTest {
                 "area[\"name\"=\"Vannes\"][\"historic\"](47.0,-3.0,48.0,-2.0););", set.toString());
 
         //Test request format
-        assertEquals("[out:json];out;", new Query().format(new JsonOutFormat()).toString());
+        assertEquals("[out:json];", new Query().format(new JsonOutFormat()).toString());
         assertEquals("[out:csv(::\"id\",\"amenity\",\"contact:website\")];out;",
-                new Query().format(new CsvOutFormat("::id", "amenity", "contact:website")).toString());
+                new Query().format(new CsvOutFormat("::id", "amenity", "contact:website")).out().toString());
         assertEquals("[out:json][timeout:900][maxsize:1073741824];();out skel;",
                 new Query().format(new JsonOutFormat()).timeout(900).maxsize(1073741824)
                         .dataSet(new Set()).out(Out.skel).toString());
+        assertEquals("[out:xml][bbox:25.0,6.02,28.68,7.85];();out;",  new Query().format(new XmlOutFormat())
+                .bbox(25.0, 6.02, 28.68, 7.85).dataSet(new Set()).out().toString());
 
         //Recurse tests
         assertEquals("<;", new RecurseUp().toString());
@@ -83,7 +126,7 @@ public class QueryTest {
         assertEquals(".a>->.b;", new RecurseDown("a").setAlias("b").toString());
 
         //For Each tests
-        assertEquals("foreach.a{out;}->.b;", new ForEach("a", new Query()).setAlias("b").toString());
+        assertEquals("foreach.a->.b();", new ForEach("a", new Query()).setAlias("b").toString());
 
         //For Each tests
         assertEquals(".a map_to_area->.b;", new MapToArea("a").setAlias("b").toString());
@@ -91,16 +134,51 @@ public class QueryTest {
 
     @Test
     public void groovyQueryTest() {
-
         //Test subsets
+        //Test Node
         String node = "node(bbox(47.0,-3.0,48.0,-2.0),\"name=Vannes\", \"population\")";
         assertEquals("node[\"name\"=\"Vannes\"][\"population\"](47.0,-3.0,48.0,-2.0);", shell.evaluate(node).toString());
+        String nodeNoBBox = "node(\"name=Vannes\", \"population\")";
+        assertEquals("node[\"name\"=\"Vannes\"][\"population\"];", shell.evaluate(nodeNoBBox).toString());
+
+        //Test Way
         String way = "way(bbox(47.0,-3.0,48.0,-2.0),\"name=Vannes\", \"website\")";
         assertEquals("way[\"name\"=\"Vannes\"][\"website\"](47.0,-3.0,48.0,-2.0);", shell.evaluate(way).toString());
+
+        //Test Rel
         String rel = "rel(bbox(47.0,-3.0,48.0,-2.0),\"name=Vannes\", \"capital\")";
         assertEquals("rel[\"name\"=\"Vannes\"][\"capital\"](47.0,-3.0,48.0,-2.0);", shell.evaluate(rel).toString());
+
+        //Test Area
         String area = "area(bbox(47.0,-3.0,48.0,-2.0),\"name=Vannes\", \"historic\")";
         assertEquals("area[\"name\"=\"Vannes\"][\"historic\"](47.0,-3.0,48.0,-2.0);", shell.evaluate(area).toString());
+
+        //Test set add and remove
+        String set1 = "set(node(\"name=Vannes\", \"population\"), way(\"name=Vannes\", \"population\")," +
+                "rel(\"name=Vannes\", \"population\"))";
+        String set2 = "set(node(\"name=Vannes\", \"historic\"), way(\"name=Vannes\", \"historic\")," +
+                "rel(\"name=Vannes\", \"historic\"))";
+        assertEquals("(node[\"name\"=\"Vannes\"][\"population\"];way[\"name\"=\"Vannes\"][\"population\"];" +
+                        "rel[\"name\"=\"Vannes\"][\"population\"];node[\"name\"=\"Vannes\"][\"historic\"];" +
+                        "way[\"name\"=\"Vannes\"][\"historic\"];rel[\"name\"=\"Vannes\"][\"historic\"];);",
+                shell.evaluate(set1+"+"+set2).toString());
+        assertEquals("(node[\"name\"=\"Vannes\"][\"population\"];way[\"name\"=\"Vannes\"][\"population\"];" +
+                        "rel[\"name\"=\"Vannes\"][\"population\"];-node[\"name\"=\"Vannes\"][\"historic\"];" +
+                        "-way[\"name\"=\"Vannes\"][\"historic\"];-rel[\"name\"=\"Vannes\"][\"historic\"];);",
+                shell.evaluate(set1+"-"+set2).toString());
+
+        //Test operator
+        String nodeOp = "node(\"name=Vannes\", \"name!=Vannes\", \"name!~Vannes\", \"name~Vannes\", \"!name\")";
+        assertEquals("node[\"name\"=\"Vannes\"][\"name\"!=\"Vannes\"][\"name\"!~\"Vannes\"][\"name\"~\"Vannes\"]" +
+                "[!\"name\"];", shell.evaluate(nodeOp).toString());
+
+        //Test comparison filter
+        String compFilter = "node(bbox(47, -3, 48, -2), \"building:levels>=3\", \"building:levels<5\")";
+        assertEquals("node(if:t[\"building:levels\"]>=3)(if:t[\"building:levels\"]<5)(47.0,-3.0,48.0,-2.0);",
+                shell.evaluate(compFilter).toString());
+        compFilter = "node(bbox(47, -3, 48, -2), \"building:levels > 3\", \"building:levels<=5\")";
+        assertEquals("node(if:t[\"building:levels\"]>3)(if:t[\"building:levels\"]<=5)(47.0,-3.0,48.0,-2.0);",
+                shell.evaluate(compFilter).toString());
 
         //Test set
         String set = "set("+node+","+way+","+rel+","+area+");";
@@ -110,11 +188,13 @@ public class QueryTest {
                 "area[\"name\"=\"Vannes\"][\"historic\"](47.0,-3.0,48.0,-2.0););", shell.evaluate(set).toString());
 
         //Test request format
-        assertEquals("[out:json];out;", shell.evaluate("query() format json").toString());
+        assertEquals("[out:json];", shell.evaluate("query() format json").toString());
         assertEquals("[out:csv(::\"id\",\"amenity\",\"contact:website\")];out;",
-                shell.evaluate("query() format csv(\"::id\", \"amenity\", \"contact:website\")").toString());
+                shell.evaluate("query() format csv(\"::id\", \"amenity\", \"contact:website\") out()").toString());
         assertEquals("[out:json][timeout:900][maxsize:1073741824];();out skel;",
                 shell.evaluate("query() format json timeout 900 maxsize 1073741824 dataSet set() out skel").toString());
+        assertEquals("[out:xml][bbox:25.0,6.02,28.68,7.85];();out;",
+                shell.evaluate("query().format(xml).bbox(25.0, 6.02, 28.68, 7.85).dataSet(set()).out()").toString());
 
         //Recurse tests
         assertEquals("<;",shell.evaluate("recurseUp()").toString());
@@ -128,7 +208,7 @@ public class QueryTest {
         assertEquals(".a>->.b;", shell.evaluate("recurseDown(\"a\")>>\"b\"").toString());
 
         //For Each tests
-        assertEquals("foreach.a{out;}->.b;",shell.evaluate("foreach(\"a\", query())>>\"b\"").toString());
+        assertEquals("foreach.a->.b();",shell.evaluate("foreach(\"a\", query())>>\"b\"").toString());
 
         //For Each tests
         assertEquals(".a map_to_area->.b;", shell.evaluate("map_to_area(\"a\")>>\"b\"").toString());
@@ -137,18 +217,30 @@ public class QueryTest {
     @Test
     public void groovyQueryExecuteFileTest() {
         String filePath = "target/osm_data.json";
+        String badQuery = "query() format json timeout 900 maxsize 1073741824 dataSet set(node(\"\\\"\")) out skel execute ";
         String query = "query() format json timeout 900 maxsize 1073741824 dataSet set() out skel execute ";
         //Create the file
-        shell.evaluate(query + "\"" +filePath + "\"");
-        Assert.assertTrue(new File(filePath).exists());
+        assertEquals(true, shell.evaluate(query + "\"" +filePath + "\""));
+        assertTrue(new File(filePath).exists());
         //Append in an existing file
-        shell.evaluate(query + "(\"" + filePath+ "\", true)");
+        assertEquals(true, shell.evaluate(query + "(\"" + filePath+ "\", true)"));
 
         filePath = "target/osm_data2.json";
         //Create the file
-        shell.evaluate(query + "(\"" + filePath+ "\", false)");
-        Assert.assertTrue(new File(filePath).exists());
+        assertEquals(true, shell.evaluate(query + "(\"" + filePath+ "\", false)"));
+        assertTrue(new File(filePath).exists());
 
+        //Test bad request
+        filePath = "target/osm_data2.json";
+        //Create the file
+        assertEquals(false, shell.evaluate(badQuery + "(\"" + filePath+ "\", false)"));
+        assertTrue(new File(filePath).exists());
+
+        //Test the stream
+        Object o = shell.evaluate(query + "()");
+        assertTrue(o instanceof InputStream);
+        o = shell.evaluate(badQuery + "()");
+        assertTrue(o instanceof InputStream);
     }
     
 }


### PR DESCRIPTION
Changes the syntax of foreach : foreach->.a() instead of foreach{}->.a,
Make SubSet class extends Set to be able to put not only Sets in dataSet,
Adds test in order to improve coverage,
Adds a methods to set the request server for the execution,
Adds DefaultSet missing call methods.
If the request failed, print the error in the file or return it in the inputstream.